### PR TITLE
Clean up headings and links when there is no relevant content

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -16,7 +16,9 @@
       {{- end }}
 
       {{- /* list content */}}
-      <h2>See</h2>
+      {{ if .Pages }}
+      <h2>See</h2><div class="post-entries">
+      {{ end }}
 
       {{- /* list items */}}
       {{- if eq .Params.list_type "docs_list" }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -53,7 +53,9 @@
   {{- /* site footer links */}}
   <nav class="navbar">
     <ul class="navbar__list">
+      {{- if os.FileExists "/content/posts" -}}
       <li><a href="{{ absURL "posts/index.xml" }}">RSS</a></li>
+      {{- end -}}
       <li><a href="{{ absURL "sitemap.xml" }}">Sitemap</a></li>
       {{- $gitRepoUrl := "" -}}
       {{- if (isset site.Params "git_info") -}}


### PR DESCRIPTION
* When there are no posts, do not show the 'posts/index' RSS Feed
* When there are no sub-pages, do not show the 'See' header